### PR TITLE
update fluentd version

### DIFF
--- a/fluent-plugin-nata2.gemspec
+++ b/fluent-plugin-nata2.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'fluentd', '~> 0.10.45'
+  spec.add_runtime_dependency 'fluentd', '~> 0.12.0'
   spec.add_runtime_dependency 'fluent-mixin-rewrite-tag-name'
   spec.add_runtime_dependency 'mysql-slowquery-parser'
 


### PR DESCRIPTION
 日本語で失礼します

現在のstableなRubyのバージョンではv0.10系は動かないので指定しているfluentdのバージョンをアップデートさせていただきました

手元の環境 `ruby:2.4.1` `gem:2.6.11` で下記の方法でインストールできました

```
git clone https://github.com/Konboi/fluent-plugin-nata2.git
cd fluent-plugin-nata2
git branch update-fluentd-version
gem build fluent-plugin-nata2.gespec
gem install fluent-plugin-nata2.gem
```

よろしくお願いします